### PR TITLE
fix for issue #42

### DIFF
--- a/src/plugin/obfuscator.js
+++ b/src/plugin/obfuscator.js
@@ -612,7 +612,12 @@ function unpackCall(path) {
     if (!t.isObjectProperty(prop)) {
       return
     }
-    let key = prop.key.value
+    let key
+    if (t.isIdentifier(prop.key)) {
+      key = prop.key.name
+    } else {
+      key = prop.key.value
+    }
     if (t.isFunctionExpression(prop.value)) {
       // 符合要求的函数必须有且仅有一条return语句
       if (prop.value.body.body.length !== 1) {


### PR DESCRIPTION
PR #39 将stringLiteral简化为了Identifier，但由于其所在函数`purifyCode`在代码块解混淆前被调用，破坏了代码块解混淆的运作。现更新方法`unpackCall`，支持识别Identifier类型的key。

close #42
