### PR TITLE
obfuscator: Update mothods for handling custom codes (self-defending, debug-protection, console-output)

### DIFF
--- a/src/plugin/obfuscator.js
+++ b/src/plugin/obfuscator.js
@@ -1189,16 +1189,6 @@ const deleteObfuscatorCode = {
     let callee = node.callee
     let args = node.arguments
 
-    let sourceCode = path.toString()
-    if (
-      args.length == 0 &&
-      sourceCode.includes('constructor') &&
-      sourceCode.includes('setInterval')
-    ) {
-      path.remove()
-      return
-    }
-
     if (!t.isIdentifier(callee, { name: 'setInterval' })) {
       return
     }
@@ -1230,7 +1220,7 @@ const deleteObfuscatorCode = {
       return
     }
 
-    sourceCode = binding.path.toString()
+    let sourceCode = binding.path.toString()
     if (sourceCode.includes('constructor') || sourceCode.includes('debugger')) {
       path.remove()
       binding.path.remove()

--- a/src/plugin/obfuscator.js
+++ b/src/plugin/obfuscator.js
@@ -1147,8 +1147,7 @@ const deleteSelfDefendingCode = {
     if (!checkPattern(block, pattern)) {
       return
     }
-    const scope = path.scope
-    const refs = scope.bindings[selfName].referencePaths
+    const refs = path.scope.bindings[selfName].referencePaths
     for (let ref of refs) {
       if (ref.key == 'callee') {
         ref.parentPath.remove()
@@ -1157,6 +1156,7 @@ const deleteSelfDefendingCode = {
     }
     path.remove()
     console.info(`Remove SelfDefendingFunc: ${selfName}`)
+    const scope = path.scope.getBinding(callName).scope
     scope.crawl()
     const bind = scope.bindings[callName]
     if (bind.referenced) {
@@ -1214,7 +1214,7 @@ const deleteDebugProtectionCode = {
       const up1 = ref.getFunctionParent()
       const callName = up1.parent.callee.name
       const up2 = up1.getFunctionParent().parentPath
-      const scope2 = up2.scope
+      const scope2 = up2.scope.getBinding(callName).scope
       up2.remove()
       scope1.crawl()
       scope2.crawl()


### PR DESCRIPTION
The templates are provided as follows:

* [self-defending](https://github.com/javascript-obfuscator/javascript-obfuscator/blob/master/src/custom-code-helpers/self-defending)
* [debug-protection](https://github.com/javascript-obfuscator/javascript-obfuscator/tree/master/src/custom-code-helpers/debug-protection)
* [console-output](https://github.com/javascript-obfuscator/javascript-obfuscator/tree/master/src/custom-code-helpers/console-output)

Currently, I have only deleted some incorrect codes (affects issue #34), and there is still work to be done (finished).

In this patch, the id and init of a VariableDeclarator, or the id and params of a FunctionDeclaration will be used to generate the feature pattern. If the source code matches the pattern, the chance of mistakenly removing the extra code is very low.
