### PR TITLE
visitor: move delete-unused-variables to a single file and add exceptions

### DIFF
--- a/src/plugin/obfuscator.js
+++ b/src/plugin/obfuscator.js
@@ -1057,28 +1057,8 @@ function purifyCode(ast) {
   })
   // 删除未使用的变量
   traverse(ast, splitVariableDeclarator)
-  traverse(ast, {
-    VariableDeclarator: (path) => {
-      const { node, scope } = path
-      const name = node.id.name
-      const binding = scope.getBinding(name)
-      if (!binding || binding.referenced || !binding.constant) {
-        return
-      }
-      const pathpp = path.parentPath.parentPath
-      if (t.isForOfStatement(pathpp)) {
-        return
-      }
-      console.log(`未引用变量: ${name}`)
-      if (path.parentPath.node.declarations.length === 1) {
-        path.parentPath.remove()
-        path.parentPath.scope.crawl()
-      } else {
-        path.remove()
-        scope.crawl()
-      }
-    },
-  })
+  const deleteUnusedVar = require('../visitor/delete-unused-var')
+  traverse(ast, deleteUnusedVar)
   // 替换索引器
   function FormatMember(path) {
     let curNode = path.node

--- a/src/plugin/sojson.js
+++ b/src/plugin/sojson.js
@@ -763,26 +763,8 @@ function purifyCode(ast) {
     },
   })
   // 删除未使用的变量
-  traverse(ast, {
-    VariableDeclarator: (path) => {
-      let { node, scope } = path
-      const name = node.id.name
-      let binding = scope.getBinding(name)
-      if (!binding || binding.referenced || !binding.constant) {
-        return
-      }
-      const path_p = path.parentPath
-      if (path_p && t.isForOfStatement(path_p.parentPath)) {
-        return
-      }
-      console.log(`未引用变量: ${name}`)
-      if (path_p.node.declarations.length === 1) {
-        path_p.remove()
-      } else {
-        path.remove()
-      }
-    },
-  })
+  const deleteUnusedVar = require('../visitor/delete-unused-var')
+  traverse(ast, deleteUnusedVar)
   return ast
 }
 

--- a/src/plugin/sojsonv7.js
+++ b/src/plugin/sojsonv7.js
@@ -941,26 +941,8 @@ function purifyCode(ast) {
     },
   })
   // 删除未使用的变量
-  traverse(ast, {
-    VariableDeclarator: (path) => {
-      let { node, scope } = path
-      const name = node.id.name
-      let binding = scope.getBinding(name)
-      if (!binding || binding.referenced || !binding.constant) {
-        return
-      }
-      const path_p = path.parentPath
-      if (path_p && t.isForOfStatement(path_p.parentPath)) {
-        return
-      }
-      console.log(`未引用变量: ${name}`)
-      if (path_p.node.declarations.length === 1) {
-        path_p.remove()
-      } else {
-        path.remove()
-      }
-    },
-  })
+  const deleteUnusedVar = require('../visitor/delete-unused-var')
+  traverse(ast, deleteUnusedVar)
 }
 
 module.exports = function (code) {

--- a/src/visitor/delete-unused-var.js
+++ b/src/visitor/delete-unused-var.js
@@ -1,0 +1,35 @@
+const t = require('@babel/types')
+
+/**
+ * Delete unused variables with the following exceptions:
+ *
+ * - ForOfStatement
+ * - ForInStatement
+ *
+ */
+module.exports = {
+  VariableDeclarator: (path) => {
+    const { node, scope } = path
+    const name = node.id.name
+    const binding = scope.getBinding(name)
+    if (!binding || binding.referenced || !binding.constant) {
+      return
+    }
+    const up1 = path.parentPath
+    const up2 = up1?.parentPath
+    if (t.isForOfStatement(up2)) {
+      return
+    }
+    if (t.isForInStatement(up2)) {
+      return
+    }
+    console.log(`Unused variable: ${name}`)
+    if (up1.node.declarations.length === 1) {
+      up1.remove()
+      up1.scope.crawl()
+    } else {
+      path.remove()
+      scope.crawl()
+    }
+  },
+}


### PR DESCRIPTION
This lint config is used in multiple plugins. Thus, it's better to be posited in the visitor folder.

Meanwhile, the `ForInStatement` exception is added regarding #50 