### PR TITLE
obfuscator: bug fix and improve compatibility

### DIFF
--- a/src/plugin/obfuscator.js
+++ b/src/plugin/obfuscator.js
@@ -181,7 +181,11 @@ function stringArrayV2(ast) {
     const node = t.expressionStatement(path.node)
     obj.stringArrayCodes.push(generator(node, { minified: true }).code)
     path.stop()
-    path.remove()
+    if (path.parentPath.isUnaryExpression()) {
+      path.parentPath.remove()
+    } else {
+      path.remove()
+    }
   }
   traverse(ast, { CallExpression: find_rotate_function })
   if (obj.stringArrayCodes.length < 3 || !obj.stringArrayCalls.length) {

--- a/src/plugin/obfuscator.js
+++ b/src/plugin/obfuscator.js
@@ -131,8 +131,8 @@ function stringArrayV2(ast) {
     obj.stringArrayName = args[0].name
     // The string array can be found by its binding
     const bind = path.scope.getBinding(obj.stringArrayName)
-    const def = bind.path.parentPath
-    obj.stringArrayCodes.push(generator(def.node, { minified: true }).code)
+    const def = t.variableDeclaration('var', [bind.path.node])
+    obj.stringArrayCodes.push(generator(def, { minified: true }).code)
     // The calls can be found by its references
     for (let ref of bind.referencePaths) {
       if (ref?.listKey === 'arguments') {
@@ -176,7 +176,7 @@ function stringArrayV2(ast) {
       up2.remove()
     }
     // Remove the string array
-    def.remove()
+    bind.path.remove()
     // Add the rotate function
     const node = t.expressionStatement(path.node)
     obj.stringArrayCodes.push(generator(node, { minified: true }).code)

--- a/src/plugin/obfuscator.js
+++ b/src/plugin/obfuscator.js
@@ -116,14 +116,15 @@ function stringArrayV2(ast) {
     if (
       !callee.isFunctionExpression() ||
       callee.node.params.length !== 2 ||
-      args.length !== 2 ||
+      args.length == 0 ||
+      args.length > 2 ||
       !t.isIdentifier(args[0])
     ) {
       return
     }
     const arr = callee.node.params[0].name
-    const cmpV = callee.node.params[1].name
-    const fp = `while(){try{if(==${cmpV})else${arr}push(${arr}shift())}catch(){${arr}push(${arr}shift())}}`
+    // const cmpV = callee.node.params[1].name
+    const fp = `(){try{if()break${arr}push(${arr}shift())}catch(){${arr}push(${arr}shift())}}`
     const code = '' + callee.get('body')
     if (!checkPattern(code, fp)) {
       return

--- a/src/plugin/obfuscator.js
+++ b/src/plugin/obfuscator.js
@@ -61,6 +61,10 @@ function decodeObject(ast) {
     if (!Object.prototype.hasOwnProperty.call(obj_node, name.name)) {
       return
     }
+    if (t.isIdentifier(key) && path.node.computed) {
+      // In this case, the identifier points to another value
+      return
+    }
     path.replaceWith(obj_node[name.name][key.name])
     obj_used[name.name] = true
   }
@@ -673,7 +677,7 @@ function unpackCall(path) {
         if (!t.isIdentifier(retStmt.argument.callee)) {
           return
         }
-        if (retStmt.argument.callee.name !== prop.value.params[0].name) {
+        if (retStmt.argument.callee.name !== prop.value.params[0]?.name) {
           return
         }
         repfunc = function (_path, args) {

--- a/src/plugin/obfuscator.js
+++ b/src/plugin/obfuscator.js
@@ -371,13 +371,18 @@ function decodeGlobal(ast) {
   function do_collect_remove(path) {
     // 可以删除所有已收集混淆函数的定义
     // 因为根函数已被删除 即使保留也无法运行
-    let name = path.node?.left?.name
-    if (!name) {
-      name = path.node?.id?.name
+    let node = path.node?.left
+    if (!node) {
+      node = path.node?.id
     }
+    let name = node?.name
     if (exist_names.indexOf(name) != -1) {
       // console.log(`del: ${name}`)
-      path.remove()
+      if (path.parentPath.isCallExpression()) {
+        path.replaceWith(node)
+      } else {
+        path.remove()
+      }
     }
   }
   function do_collect_func(path) {


### PR DESCRIPTION
This patch is made based on the example in #50

Several bugs are fixed in this patch:

* Ignore cumputed member expressions when replacing object values
* Create a variableDeclaration node when generating string array code to avoid additional definitions
* Remove the parent node of the rotate function if it's enclosed by UnaryExpression
* Preserve the left value when AssignmentExpression is enclosed by CallExpression (Nested call)
* The `unpackCall` method may throw an error when the FunctionExpression of a prop does not have params

One improvement is made:

* simplify validation in stringArrayV2 to support more scenarios (**obfuscator-similar** string array encoding)
* add a method for extracting simple string array
