### PR TITLE
obfuscator: update stringArrayV2 to support rotate function (v < 2.10.0)

### DIFF
--- a/src/plugin/obfuscator.js
+++ b/src/plugin/obfuscator.js
@@ -123,10 +123,13 @@ function stringArrayV2(ast) {
       return
     }
     const arr = callee.node.params[0].name
-    // const cmpV = callee.node.params[1].name
-    const fp = `(){try{if()break${arr}push(${arr}shift())}catch(){${arr}push(${arr}shift())}}`
+    const cmpV = callee.node.params[1].name
+    // >= 2.10.0
+    const fp1 = `(){try{if()break${arr}push(${arr}shift())}catch(){${arr}push(${arr}shift())}}`
+    // < 2.10.0
+    const fp2 = `const=function(){while(--){${arr}push(${arr}shift)}}${cmpV}`
     const code = '' + callee.get('body')
-    if (!checkPattern(code, fp)) {
+    if (!checkPattern(code, fp1) && !checkPattern(code, fp2)) {
       return
     }
     obj.stringArrayName = args[0].name


### PR DESCRIPTION
close #60 

After PR #55, the recognition of RotateFunction is more strict. However, the template of RotateFunction in versions below 2.10.0 (javascript-obfuscator/javascript-obfuscator@efac711ce40cea34cb2747ba6bba9b7385667c6e) is relatively simplified.

This PR adds a pattern string to match RotateFunction of this version.
