### PR TITLE
chore: convert CommonJS to ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "decode-js",
+  "type": "module",
   "scripts": {
     "decode": "node src/main.js",
     "deob": "node src/main.js -t obfuscator",

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,10 @@
-﻿const fs = require('fs')
-const PluginCommon = require('./plugin/common.js')
-const PluginJjencode = require('./plugin/jjencode.js')
-const PluginSojson = require('./plugin/sojson.js')
-const PluginSojsonV7 = require('./plugin/sojsonv7.js')
-const PluginObfuscator = require('./plugin/obfuscator.js')
-const PluginAwsc = require('./plugin/awsc.js')
+import fs from 'fs'
+import PluginCommon from './plugin/common.js'
+import PluginJjencode from './plugin/jjencode.js'
+import PluginSojson from './plugin/sojson.js'
+import PluginSojsonV7 from './plugin/sojsonv7.js'
+import PluginObfuscator from './plugin/obfuscator.js'
+import PluginAwsc from './plugin/awsc.js'
 
 // 读取参数
 let type = 'common'

--- a/src/main.js
+++ b/src/main.js
@@ -25,26 +25,32 @@ console.log(`类型: ${type}`)
 console.log(`输入: ${encodeFile}`)
 console.log(`输出: ${decodeFile}`)
 
-// 读取源代码
-const sourceCode = fs.readFileSync(encodeFile, { encoding: 'utf-8' })
+const main = () => {
+  // 读取源代码
+  const sourceCode = fs.readFileSync(encodeFile, { encoding: 'utf-8' })
 
-// 净化源代码
-let code
-if (type === 'sojson') {
-  code = PluginSojson(sourceCode)
-} else if (type === 'sojsonv7') {
-  code = PluginSojsonV7(sourceCode)
-} else if (type === 'obfuscator') {
-  code = PluginObfuscator(sourceCode)
-} else if (type === 'awsc') {
-  code = PluginAwsc(sourceCode)
-} else if (type === 'jjencode') {
-  code = PluginJjencode(sourceCode)
-} else {
-  code = PluginCommon(sourceCode)
+  // 净化源代码
+  let code
+  if (type === 'sojson') {
+    code = PluginSojson(sourceCode)
+  } else if (type === 'sojsonv7') {
+    code = PluginSojsonV7(sourceCode)
+  } else if (type === 'obfuscator') {
+    code = PluginObfuscator(sourceCode)
+  } else if (type === 'awsc') {
+    code = PluginAwsc(sourceCode)
+  } else if (type === 'jjencode') {
+    code = PluginJjencode(sourceCode)
+  } else {
+    code = PluginCommon(sourceCode)
+  }
+
+  // 输出代码
+  if (code) {
+    fs.writeFile(decodeFile, code, () => {})
+  }
 }
 
-// 输出代码
-if (code) {
-  fs.writeFile(decodeFile, code, () => {})
-}
+process.nextTick(async () => {
+  main()
+})

--- a/src/plugin/awsc.js
+++ b/src/plugin/awsc.js
@@ -2,10 +2,12 @@
  * Reference：
  * * [某宝登录bx-ua参数逆向思路(fireyejs 225算法)](https://zhuanlan.zhihu.com/p/626187669)
  */
-const { parse } = require('@babel/parser')
-const generator = require('@babel/generator').default
-const traverse = require('@babel/traverse').default
-const t = require('@babel/types')
+import { parse } from '@babel/parser'
+import _generate from '@babel/generator'
+const generator = _generate.default
+import _traverse from '@babel/traverse'
+const traverse = _traverse.default
+import * as t from '@babel/types'
 
 function RemoveVoid(path) {
   if (path.node.operator === 'void') {
@@ -204,7 +206,7 @@ function LintBlock(path) {
   path.replaceWith(t.blockStatement(arr))
 }
 
-module.exports = function (code) {
+export default function (code) {
   let ast = parse(code)
   // Lint
   traverse(ast, {

--- a/src/plugin/common.js
+++ b/src/plugin/common.js
@@ -1,8 +1,14 @@
-const { parse } = require('@babel/parser')
-const generator = require('@babel/generator').default
-const traverse = require('@babel/traverse').default
+import { parse } from '@babel/parser'
+import _generate from '@babel/generator'
+const generator = _generate.default
+import _traverse from '@babel/traverse'
+const traverse = _traverse.default
+import deleteUnreachableCode from '../visitor/delete-unreachable-code.js'
+import deleteNestedBlocks from '../visitor/delete-nested-blocks.js'
+import calculateConstantExp from '../visitor/calculate-constant-exp.js'
+import calculateRString from '../visitor/calculate-rstring.js'
 
-module.exports = function (code) {
+export default function (code) {
   let ast
   try {
     ast = parse(code, { errorRecovery: true })
@@ -10,13 +16,9 @@ module.exports = function (code) {
     console.error(`Cannot parse code: ${e.reasonCode}`)
     return null
   }
-  const deleteUnreachableCode = require('../visitor/delete-unreachable-code')
   traverse(ast, deleteUnreachableCode)
-  const deleteNestedBlocks = require('../visitor/delete-nested-blocks')
   traverse(ast, deleteNestedBlocks)
-  const calculateConstantExp = require('../visitor/calculate-constant-exp')
   traverse(ast, calculateConstantExp)
-  const calculateRString = require('../visitor/calculate-rstring')
   traverse(ast, calculateRString)
   code = generator(ast).code
   return code

--- a/src/plugin/eval.js
+++ b/src/plugin/eval.js
@@ -1,7 +1,9 @@
-const { parse } = require('@babel/parser')
-const generator = require('@babel/generator').default
-const traverse = require('@babel/traverse').default
-const t = require('@babel/types')
+import { parse } from '@babel/parser'
+import _generate from '@babel/generator'
+const generator = _generate.default
+import _traverse from '@babel/traverse'
+const traverse = _traverse.default
+import * as t from '@babel/types'
 
 function unpack(code) {
   let ast = parse(code, { errorRecovery: true })
@@ -46,7 +48,7 @@ function pack(code) {
   return code
 }
 
-module.exports = {
+export default {
   unpack,
   pack,
 }

--- a/src/plugin/jjencode.js
+++ b/src/plugin/jjencode.js
@@ -57,7 +57,7 @@ function getCode(code) {
  * This encoding method originates from http://utf-8.jp/public/jjencode.html,
  * and it does not change the original code (encoder, not obfuscation).
  */
-module.exports = function (code) {
+export default function (code) {
   code = getCode(code)
   if (!code) {
     return null

--- a/src/plugin/sojsonv7.js
+++ b/src/plugin/sojsonv7.js
@@ -1,13 +1,20 @@
 /**
  * For jsjiami.com.v7
  */
-const { parse } = require('@babel/parser')
-const generator = require('@babel/generator').default
-const traverse = require('@babel/traverse').default
-const t = require('@babel/types')
-const ivm = require('isolated-vm')
-const PluginEval = require('./eval.js')
-const calculateConstantExp = require('../visitor/calculate-constant-exp')
+import { parse } from '@babel/parser'
+import _generate from '@babel/generator'
+const generator = _generate.default
+import _traverse from '@babel/traverse'
+const traverse = _traverse.default
+import * as t from '@babel/types'
+import ivm from 'isolated-vm'
+import PluginEval from './eval.js'
+import calculateConstantExp from '../visitor/calculate-constant-exp.js'
+import deleteIllegalReturn from '../visitor/delete-illegal-return.js'
+import deleteUnusedVar from '../visitor/delete-unused-var.js'
+import parseControlFlowStorage from '../visitor/parse-control-flow-storage.js'
+import pruneIfBranch from '../visitor/prune-if-branch.js'
+import splitSequence from '../visitor/split-sequence.js'
 
 const isolate = new ivm.Isolate()
 const globalContext = isolate.createContextSync()
@@ -490,7 +497,6 @@ function cleanSwitchCode2(path) {
 
 function cleanDeadCode(ast) {
   traverse(ast, calculateConstantExp)
-  const pruneIfBranch = require('../visitor/prune-if-branch')
   traverse(ast, pruneIfBranch)
   traverse(ast, { WhileStatement: { exit: cleanSwitchCode1 } })
   traverse(ast, { ForStatement: { exit: cleanSwitchCode2 } })
@@ -735,7 +741,6 @@ function purifyCode(ast) {
   }
   traverse(ast, { MemberExpression: FormatMember })
   // 分割表达式
-  const splitSequence = require('../visitor/split-sequence')
   traverse(ast, splitSequence)
   // 删除空语句
   traverse(ast, {
@@ -744,11 +749,10 @@ function purifyCode(ast) {
     },
   })
   // 删除未使用的变量
-  const deleteUnusedVar = require('../visitor/delete-unused-var')
   traverse(ast, deleteUnusedVar)
 }
 
-module.exports = function (code) {
+export default function (code) {
   let ret = PluginEval.unpack(code)
   let global_eval = false
   if (ret) {
@@ -763,7 +767,6 @@ module.exports = function (code) {
     return null
   }
   // IllegalReturn
-  const deleteIllegalReturn = require('../visitor/delete-illegal-return')
   traverse(ast, deleteIllegalReturn)
   // 清理二进制显示内容
   traverse(ast, {
@@ -782,7 +785,6 @@ module.exports = function (code) {
     return null
   }
   console.log('处理代码块加密...')
-  const parseControlFlowStorage = require('../visitor/parse-control-flow-storage')
   traverse(ast, parseControlFlowStorage)
   console.log('清理死代码...')
   ast = cleanDeadCode(ast)

--- a/src/visitor/calculate-constant-exp.js
+++ b/src/visitor/calculate-constant-exp.js
@@ -1,5 +1,6 @@
-const generator = require('@babel/generator').default
-const t = require('@babel/types')
+import _generate from '@babel/generator'
+const generator = _generate.default
+import * as t from '@babel/types'
 
 function checkLiteral(node) {
   if (t.isNumericLiteral(node)) {
@@ -101,7 +102,7 @@ function calculateUnaryExpression(path) {
   }
 }
 
-module.exports = {
+export default {
   BinaryExpression: { exit: calculateBinaryExpression },
   UnaryExpression: { exit: calculateUnaryExpression },
 }

--- a/src/visitor/calculate-rstring.js
+++ b/src/visitor/calculate-rstring.js
@@ -1,10 +1,11 @@
-const generator = require('@babel/generator').default
-const t = require('@babel/types')
+import _generate from '@babel/generator'
+const generator = _generate.default
+import * as t from '@babel/types'
 
 /**
  * "sh".split("").reverse().join("") -> "hs"
  */
-module.exports = {
+export default {
   StringLiteral(path) {
     if (path.key !== 'object') {
       return

--- a/src/visitor/delete-extra.js
+++ b/src/visitor/delete-extra.js
@@ -2,7 +2,7 @@
  * 0x10 -> 16, "\u0058" -> "X"
  * not ASCII-safe (disable jsescOption:minimal to keep ASCII-safe)
  */
-module.exports = {
+export default {
   StringLiteral: ({ node }) => {
     delete node.extra
   },

--- a/src/visitor/delete-illegal-return.js
+++ b/src/visitor/delete-illegal-return.js
@@ -1,7 +1,7 @@
 /**
  * delete ReturnStatement in Program scope
  */
-module.exports = {
+export default {
   ReturnStatement(path) {
     if (!path.getFunctionParent()) {
       path.remove()

--- a/src/visitor/delete-nested-blocks.js
+++ b/src/visitor/delete-nested-blocks.js
@@ -14,7 +14,7 @@ const isIntersect = (path, bindings) => {
  * This is slightly different from the @putout/plugin-remove-nested-blocks :
  * https://github.com/coderaiser/putout/issues/224#issuecomment-2614051528
  */
-module.exports = {
+export default {
   BlockStatement: (path) => {
     const { parentPath } = path
     if (!parentPath.isBlockStatement() && !parentPath.isProgram()) {

--- a/src/visitor/delete-unreachable-code.js
+++ b/src/visitor/delete-unreachable-code.js
@@ -1,4 +1,4 @@
-const t = require('@babel/types')
+import * as t from '@babel/types'
 
 /**
  * DFS the BlockStatement to find and return the location of the first
@@ -26,7 +26,7 @@ const checkReturnLocation = (body) => {
  * This is slightly different from the @putout/plugin-remove-unreachable-code :
  * https://github.com/coderaiser/putout/issues/224#issuecomment-2614051528
  */
-module.exports = {
+export default {
   BlockStatement: (path) => {
     const body = path.node.body
     const loc = checkReturnLocation(body)

--- a/src/visitor/delete-unused-var.js
+++ b/src/visitor/delete-unused-var.js
@@ -1,4 +1,4 @@
-const t = require('@babel/types')
+import * as t from '@babel/types'
 
 /**
  * Delete unused variables with the following exceptions:
@@ -7,7 +7,7 @@ const t = require('@babel/types')
  * - ForInStatement
  *
  */
-module.exports = {
+export default {
   VariableDeclarator: (path) => {
     const { node, scope } = path
     const name = node.id.name

--- a/src/visitor/lint-if-statement.js
+++ b/src/visitor/lint-if-statement.js
@@ -1,4 +1,4 @@
-const t = require('@babel/types')
+import * as t from '@babel/types'
 
 function LintIfStatement(path) {
   let { test, consequent, alternate } = path.node
@@ -17,6 +17,8 @@ function LintIfStatement(path) {
   path.replaceWith(t.ifStatement(test, consequent, alternate))
 }
 
-module.exports = {
-  IfStatement: { exit: LintIfStatement },
+export default {
+  IfStatement: {
+    exit: LintIfStatement,
+  },
 }

--- a/src/visitor/merge-object.js
+++ b/src/visitor/merge-object.js
@@ -1,4 +1,4 @@
-const t = require('@babel/types')
+import * as t from '@babel/types'
 
 function mergeObject(path) {
   const { id, init } = path.node
@@ -206,6 +206,6 @@ function mergeObject(path) {
  * - Constant objects in the original code can be splitted
  * - AssignmentExpression can be moved to ReturnStatement
  */
-module.exports = {
+export default {
   VariableDeclarator: mergeObject,
 }

--- a/src/visitor/parse-control-flow-storage.js
+++ b/src/visitor/parse-control-flow-storage.js
@@ -1,5 +1,6 @@
-const generator = require('@babel/generator').default
-const t = require('@babel/types')
+import _generate from '@babel/generator'
+const generator = _generate.default
+import * as t from '@babel/types'
 
 function parseObject(path) {
   let node = path.node
@@ -190,7 +191,7 @@ function parseObject(path) {
  * var ee = A[x][y][...];
  * ```
  */
-module.exports = {
+export default {
   VariableDeclarator: {
     exit: parseObject,
   },

--- a/src/visitor/prune-if-branch.js
+++ b/src/visitor/prune-if-branch.js
@@ -34,7 +34,7 @@ function pruneIfBranch(path) {
  *
  * The code must be reloaded to update the references
  */
-module.exports = {
+export default {
   IfStatement: pruneIfBranch,
   ConditionalExpression: pruneIfBranch,
 }

--- a/src/visitor/split-member-object.js
+++ b/src/visitor/split-member-object.js
@@ -33,6 +33,6 @@ function splitMemberObject(path) {
  * a['b'] = c;
  * ```
  */
-module.exports = {
+export default {
   MemberExpression: splitMemberObject,
 }

--- a/src/visitor/split-sequence.js
+++ b/src/visitor/split-sequence.js
@@ -1,4 +1,4 @@
-const t = require('@babel/types')
+import * as t from '@babel/types'
 
 function doSplit(insertPath, path) {
   const expressions = path.node.expressions
@@ -48,6 +48,6 @@ function splitSequence(path) {
  * - ReturnStatement
  * - ExpressionStatement
  */
-module.exports = {
+export default {
   SequenceExpression: splitSequence,
 }

--- a/src/visitor/split-variable-declaration.js
+++ b/src/visitor/split-variable-declaration.js
@@ -1,4 +1,4 @@
-const t = require('@babel/types')
+import * as t from '@babel/types'
 
 function splitVariableDeclaration(path) {
   // The scope of a for statement is its body
@@ -26,6 +26,6 @@ function splitVariableDeclaration(path) {
  *
  * This operation will only be performed when its container is an array
  */
-module.exports = {
+export default {
   VariableDeclaration: splitVariableDeclaration,
 }


### PR DESCRIPTION
In #37 , the repo was converted to CommonJS to stop at uncaught exceptions. Recently, a new method was found:

> This has cost me a lot of wasted time as well. A workaround seems to be to run your top-level code inside `process.nextTick(async () => { ... });`.

Considering that ESM is part of the ECMAScript standard, it is time to convert this repo to ESM.
