### PR TITLE
chore: Upgrade actions/checkout and actions/setup-node versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,12 +16,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 26
           cache: 'npm' # or 'yarn' / 'pnpm'
 
       - name: Install dependencies


### PR DESCRIPTION
Updated GitHub Actions to use newer versions of checkout and setup-node.